### PR TITLE
Names with unicode characters are treated as invalid #117

### DIFF
--- a/src/seedu/addressbook/data/person/Address.java
+++ b/src/seedu/addressbook/data/person/Address.java
@@ -30,7 +30,7 @@ public class Address {
     }
 
     /**
-     * Returns true if a given string is a valid person address.
+     * Returns true if a given string is a valid person email.
      */
     public static boolean isValidAddress(String test) {
         return test.matches(ADDRESS_VALIDATION_REGEX);

--- a/src/seedu/addressbook/data/person/Name.java
+++ b/src/seedu/addressbook/data/person/Name.java
@@ -12,15 +12,8 @@ import java.util.List;
 public class Name {
 
     public static final String EXAMPLE = "John Doe";
-    public static final String MESSAGE_NAME_CONSTRAINTS = "Names should consist of letters, "
-                                                           + "spaces, numbers, ', - or .";
-    public static final String NAME_VALIDATION_REGEX = "^[\\p{L}0-9 .'-]+$";
-    // In the above:
-    // \\p{L} matches any unicode letter (like German name with accents)
-    // . used to match dots in the name E.g., John Paul Jr.
-    // ' is used to match names like d'Souza
-    // - is used to match names like Jolie-Pitt
-
+    public static final String MESSAGE_NAME_CONSTRAINTS = "Person names should be spaces or alphabetic characters";
+    public static final String NAME_VALIDATION_REGEX = "[\\p{Alpha} ]+";
     public final String fullName;
 
     /**

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -74,7 +74,7 @@
 || Tags names should be alphanumeric
 || ===================================================
 || Enter command: || [Command entered:  add []\[;] p/12345 e/valid@e.mail a/valid, address]
-|| Names should consist of letters, spaces, numbers, ', - or .
+|| Person names should be spaces or alphabetic characters
 || ===================================================
 || Enter command: || [Command entered:  add Valid Name p/not_numbers e/valid@e.mail a/valid, address]
 || Person phone numbers should only contain numbers
@@ -289,78 +289,6 @@
 || 	2. Dickson Ee Phone: 444444 Address: 444, delta street Tags: [friends]
 || 
 || 2 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  clear]
-|| Address book has been cleared!
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 
-|| 0 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Name with'arc p/99999999 e/name@arc.com a/1 long, #01-valid address, 890765]
-|| New person added: Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 
-|| 1 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add John-Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25]
-|| New person added: John-Doe Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 	2. John-Doe Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 
-|| 2 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add John-Doe jr. p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25]
-|| New person added: John-Doe jr. Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 	2. John-Doe Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	3. John-Doe jr. Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 
-|| 3 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add Björn Borg p/98765432 e/borg@gmail.com a/311, Clementi Ave 2, #02-25]
-|| New person added: Björn Borg Phone: 98765432 Email: borg@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 	2. John-Doe Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	3. John-Doe jr. Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	4. Björn Borg Phone: 98765432 Email: borg@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 
-|| 4 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add José Eduardo p/98765432 e/borg@gmail.com a/311, Clementi Ave 2, #02-25]
-|| New person added: José Eduardo Phone: 98765432 Email: borg@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. Name with'arc Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 	2. John-Doe Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	3. John-Doe jr. Phone: 98765432 Email: johnd@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	4. Björn Borg Phone: 98765432 Email: borg@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 	5. José Eduardo Phone: 98765432 Email: borg@gmail.com Address: 311, Clementi Ave 2, #02-25 Tags: 
-|| 
-|| 5 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  clear]
-|| Address book has been cleared!
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 
-|| 0 persons listed!
-|| ===================================================
-|| Enter command: || [Command entered:  add George the 3rd p/99999999 e/name@arc.com a/1 long, #01-valid address, 890765]
-|| New person added: George the 3rd Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| ===================================================
-|| Enter command: || [Command entered:  list]
-|| 	1. George the 3rd Phone: 99999999 Email: name@arc.com Address: 1 long, #01-valid address, 890765 Tags: 
-|| 
-|| 1 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!

--- a/test/input.txt
+++ b/test/input.txt
@@ -147,50 +147,6 @@
   # clears all
   clear
   list
-  
-##########################################################
-# test new regex for name
-##########################################################	 
-  # name with quote character
-  add Name with'arc p/99999999 e/name@arc.com a/1 long, #01-valid address, 890765
-  list
-  
-  # name with hyphen in between
-  add John-Doe p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25
-  list
-  
-  # name with dot in it
-  add John-Doe jr. p/98765432 e/johnd@gmail.com a/311, Clementi Ave 2, #02-25
-  list
-  
-  # name with unicode character in it
-  add Björn Borg p/98765432 e/borg@gmail.com a/311, Clementi Ave 2, #02-25
-  list
-  
-  # name with another unicode character
-  add José Eduardo p/98765432 e/borg@gmail.com a/311, Clementi Ave 2, #02-25
-  list
-    
-##########################################################
-# clear all test entries
-##########################################################
-
-  clear
-  list
-
-##########################################################
-# test new regex for name
-##########################################################	 
-  # name with number character
-  add George the 3rd p/99999999 e/name@arc.com a/1 long, #01-valid address, 890765
-  list
-  
-##########################################################
-# clear all test entries
-##########################################################
-
-  clear
-  list
 
 ##########################################################
 # test exit command


### PR DESCRIPTION
Fixes #117. 

After reverting, only alphabets and space is accepted. Do we still want to allow some punctuation that are still ascii characters?