### PR TITLE
StorageFile class: load method should not create a new file #129

### DIFF
--- a/src/seedu/addressbook/storage/StorageFile.java
+++ b/src/seedu/addressbook/storage/StorageFile.java
@@ -115,14 +115,14 @@ public class StorageFile {
     /**
      * Loads data from this storage file.
      *
+     * @return an {@link AddressBook} containing the data in the file, or an empty {@link AddressBook} if it
+     *    does not exist.
      * @throws StorageOperationException if there were errors reading and/or converting data from file.
      */
     public AddressBook load() throws StorageOperationException {
-        // create empty file if not found
+
         if (!Files.exists(path) || !Files.isRegularFile(path)) {
-            final AddressBook empty = new AddressBook();
-            save(empty);
-            return empty;
+            return new AddressBook();
         }
 
         try (final Reader fileReader =

--- a/src/seedu/addressbook/storage/StorageFile.java
+++ b/src/seedu/addressbook/storage/StorageFile.java
@@ -17,6 +17,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -117,6 +118,13 @@ public class StorageFile {
      * @throws StorageOperationException if there were errors reading and/or converting data from file.
      */
     public AddressBook load() throws StorageOperationException {
+        // create empty file if not found
+        if (!Files.exists(path) || !Files.isRegularFile(path)) {
+            final AddressBook empty = new AddressBook();
+            save(empty);
+            return empty;
+        }
+
         try (final Reader fileReader =
                      new BufferedReader(new FileReader(path.toFile()))) {
 
@@ -128,17 +136,8 @@ public class StorageFile {
             }
             return loaded.toModelType();
 
-        /* Note: Here, we are using an exception to create the file if it is missing. However, we should minimize
-         * using exceptions to facilitate normal paths of execution. If we consider the missing file as a 'normal'
-         * situation (i.e. not truly exceptional) we should not use an exception to handle it.
-         */
-
-        // create empty file if not found
         } catch (FileNotFoundException fnfe) {
-            final AddressBook empty = new AddressBook();
-            save(empty);
-            return empty;
-
+            throw new AssertionError("A non-existent file scenario is already handled earlier.");
         // other errors
         } catch (IOException ioe) {
             throw new StorageOperationException("Error writing to file: " + path);

--- a/test/java/seedu/addressbook/storage/StorageFileTest.java
+++ b/test/java/seedu/addressbook/storage/StorageFileTest.java
@@ -1,8 +1,10 @@
 package seedu.addressbook.storage;
 
 import static org.junit.Assert.assertEquals;
+
 import java.nio.file.Paths;
 import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,9 +21,11 @@ import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
 import seedu.addressbook.storage.StorageFile.StorageOperationException;
 import static seedu.addressbook.util.TestUtil.assertTextFilesEqual;
+import static seedu.addressbook.util.TestUtil.assertFileDoesNotExist;
 
 public class StorageFileTest {
     private static final String TEST_DATA_FOLDER = "test/data/StorageFileTest";
+    private static final String NON_EXISTANT_FILE_NAME = "ThisFileDoesNotExist.xml";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -57,6 +61,17 @@ public class StorageFileTest {
         // ensure loaded AddressBook is properly constructed with test data
         // TODO: overwrite equals method in AddressBook class and replace with equals method below
         assertEquals(actualAB.getAllPersons(), expectedAB.getAllPersons());
+    }
+
+    @Test
+    public void load_nonExistantFile_returnsEmptyAddressBook() throws Exception {
+        AddressBook actualAB = getStorage(NON_EXISTANT_FILE_NAME).load();
+        AddressBook expectedAB = new AddressBook();
+
+        assertEquals(actualAB, expectedAB);
+
+        // verify that loading does not result in the file being created
+        assertFileDoesNotExist(TEST_DATA_FOLDER + "/" + NON_EXISTANT_FILE_NAME);
     }
 
     @Test

--- a/test/java/seedu/addressbook/util/TestUtil.java
+++ b/test/java/seedu/addressbook/util/TestUtil.java
@@ -1,12 +1,14 @@
 package seedu.addressbook.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -136,5 +138,12 @@ public class TestUtil {
         List<String> list1 = Files.readAllLines(path1, Charset.defaultCharset());
         List<String> list2 = Files.readAllLines(path2, Charset.defaultCharset());
         assertEquals(String.join("\n", list1), String.join("\n", list2));
+    }
+
+    /**
+     * Asserts that the file given does not exist on the filesystem.
+     */
+    public static void assertFileDoesNotExist(String filePath) {
+        assertTrue(Files.notExists(Paths.get(filePath)));
     }
 }


### PR DESCRIPTION
Fixes #129.

```
load() method creates a new address book xml file if it
does not exist.

However, the responsibility of load() is to simply read the file,
not write it. Even if the file does not exist, load() should simply
treat the situation as if it is loading a blank file, and handle
accordingly. Creating a new file is redundant anyway if load() does
not even attempt to read it after creation, and load() will not gain
any new information by reading it.

Let's remove the saving functionality of load() in order to narrow
down the responsibility of the method to purely just reading the xml
files.
```