### PR TITLE
Addressbook::addTag() is not used #169

### DIFF
--- a/src/seedu/addressbook/data/AddressBook.java
+++ b/src/seedu/addressbook/data/AddressBook.java
@@ -12,7 +12,6 @@ import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
-import seedu.addressbook.data.tag.UniqueTagList.DuplicateTagException;
 import seedu.addressbook.data.tag.UniqueTagList.TagNotFoundException;
 
 /**
@@ -83,15 +82,6 @@ public class AddressBook {
     public void addPerson(Person toAdd) throws DuplicatePersonException {
         allPersons.add(toAdd);
         syncTagsWithMasterList(toAdd);
-    }
-
-    /**
-     * Adds a tag to the list of tags present in the address book.
-     *
-     * @throws DuplicateTagException if an equivalent tag already exists.
-     */
-    public void addTag(Tag toAdd) throws DuplicateTagException {
-        allTags.add(toAdd);
     }
 
     /**

--- a/src/seedu/addressbook/data/AddressBook.java
+++ b/src/seedu/addressbook/data/AddressBook.java
@@ -91,13 +91,6 @@ public class AddressBook {
     }
 
     /**
-     * Returns true if an equivalent person exists in the address book.
-     */
-    public boolean containsTag(Tag key) {
-        return allTags.contains(key);
-    }
-
-    /**
      * Removes the equivalent person from the address book.
      *
      * @throws PersonNotFoundException if no such Person could be found.

--- a/src/seedu/addressbook/data/AddressBook.java
+++ b/src/seedu/addressbook/data/AddressBook.java
@@ -12,7 +12,6 @@ import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
-import seedu.addressbook.data.tag.UniqueTagList.TagNotFoundException;
 
 /**
  * Represents the entire address book. Contains the data of the address book.
@@ -105,29 +104,6 @@ public class AddressBook {
      */
     public void removePerson(ReadOnlyPerson toRemove) throws PersonNotFoundException {
         allPersons.remove(toRemove);
-    }
-
-    /**
-     * Removes the equivalent Tag from the address book.
-     * The Tag will also be removed from any Person in the address book who has that tag.
-     *
-     * @throws TagNotFoundException if no such Tag could be found.
-     */
-    public void removeTag(Tag toRemove) throws TagNotFoundException {
-        removeTagFromAllPersons(toRemove);
-        allTags.remove(toRemove);
-    }
-
-    private void removeTagFromAllPersons(Tag toRemove) throws TagNotFoundException {
-        for (Person person : allPersons) {
-            UniqueTagList personTagList = person.getTags();
-
-            if (personTagList.contains(toRemove)) {
-                personTagList.remove(toRemove);
-            }
-
-            person.setTags(personTagList);
-        }
     }
 
     /**

--- a/src/seedu/addressbook/data/tag/UniqueTagList.java
+++ b/src/seedu/addressbook/data/tag/UniqueTagList.java
@@ -94,18 +94,6 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Adds a Tag to the list.
-     *
-     * @throws DuplicateTagException if the Tag to add is a duplicate of an existing Tag in the list.
-     */
-    public void add(Tag toAdd) throws DuplicateTagException {
-        if (contains(toAdd)) {
-            throw new DuplicateTagException();
-        }
-        internalList.add(toAdd);
-    }
-
-    /**
      * Adds all the given tags to this list.
      *
      * @throws DuplicateTagException if the argument tag list contains tag(s) that already exist in this list.

--- a/src/seedu/addressbook/data/tag/UniqueTagList.java
+++ b/src/seedu/addressbook/data/tag/UniqueTagList.java
@@ -30,12 +30,6 @@ public class UniqueTagList implements Iterable<Tag> {
         }
     }
 
-    /**
-     * Signals that an operation targeting a specified Tag in the list would fail because
-     * there is no such matching Tag in the list.
-     */
-    public static class TagNotFoundException extends Exception {}
-
     private final List<Tag> internalList = new ArrayList<>();
 
     /**
@@ -114,18 +108,6 @@ public class UniqueTagList implements Iterable<Tag> {
             if (!alreadyInside.contains(tag)) {
                 internalList.add(tag);
             }
-        }
-    }
-
-    /**
-     * Removes the equivalent Tag from the list.
-     *
-     * @throws TagNotFoundException if no such Tag could be found in the list.
-     */
-    public void remove(Tag toRemove) throws TagNotFoundException {
-        final boolean tagFoundAndDeleted = internalList.remove(toRemove);
-        if (!tagFoundAndDeleted) {
-            throw new TagNotFoundException();
         }
     }
 

--- a/test/java/seedu/addressbook/data/AddressBookTest.java
+++ b/test/java/seedu/addressbook/data/AddressBookTest.java
@@ -21,7 +21,6 @@ import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
-import seedu.addressbook.data.tag.UniqueTagList.DuplicateTagException;
 import seedu.addressbook.data.tag.UniqueTagList.TagNotFoundException;
 
 public class AddressBookTest {
@@ -120,21 +119,6 @@ public class AddressBookTest {
         }
 
         assertFalse(defaultAddressBook.containsTag(tagPrizeWinner));
-    }
-
-    @Test
-    public void addTag_tagNotInList_addsNormally() throws Exception {
-        assertFalse(defaultAddressBook.containsTag(tagEconomist));
-        defaultAddressBook.addTag(tagEconomist);
-
-        UniqueTagList expectedTagsAfterAddition = new UniqueTagList(tagMathematician, tagScientist, tagEconomist);
-        assertTrue(isIdentical(expectedTagsAfterAddition, defaultAddressBook.getAllTags()));
-    }
-
-    @Test
-    public void addTag_tagAlreadyInList_throwsDuplicateTagException() throws Exception {
-        thrown.expect(DuplicateTagException.class);
-        defaultAddressBook.addTag(tagMathematician);
     }
 
     @Test

--- a/test/java/seedu/addressbook/data/AddressBookTest.java
+++ b/test/java/seedu/addressbook/data/AddressBookTest.java
@@ -21,7 +21,6 @@ import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.data.tag.UniqueTagList;
-import seedu.addressbook.data.tag.UniqueTagList.TagNotFoundException;
 
 public class AddressBookTest {
     private Tag tagPrizeWinner;
@@ -175,40 +174,6 @@ public class AddressBookTest {
     public void removePerson_personNotExists_throwsPersonNotFoundException() throws Exception {
         thrown.expect(PersonNotFoundException.class);
         defaultAddressBook.removePerson(charlieDouglas);
-    }
-
-    @Test
-    public void removeTag_tagExistsAndUnused_removesNormally() throws Exception {
-        int numberOfTagsBeforeRemoval = getSize(defaultAddressBook.getAllTags());
-        defaultAddressBook.removeTag(tagScientist);
-
-        assertFalse(defaultAddressBook.containsTag(tagScientist));
-
-        int numberOfTagsAfterRemoval = getSize(defaultAddressBook.getAllTags());
-        assertTrue(numberOfTagsAfterRemoval == numberOfTagsBeforeRemoval - 1);
-
-    }
-
-    @Test
-    public void removeTag_tagExistsAndUsed_removesUsedTagFromPersons() throws Exception {
-        aliceBetsy.setTags(new UniqueTagList(tagMathematician, tagPrizeWinner));
-        bobChaplin.setTags(new UniqueTagList(tagEconomist));
-
-        int numberOfTagsBeforeRemoval = getSize(defaultAddressBook.getAllTags());
-        defaultAddressBook.removeTag(tagMathematician);
-
-        assertTrue(isIdentical(aliceBetsy.getTags(), new UniqueTagList(tagPrizeWinner)));
-        assertTrue(isIdentical(bobChaplin.getTags(), new UniqueTagList(tagEconomist)));
-        assertFalse(defaultAddressBook.containsTag(tagMathematician));
-
-        int numberOfTagsAfterRemoval = getSize(defaultAddressBook.getAllTags());
-        assertTrue(numberOfTagsAfterRemoval == numberOfTagsBeforeRemoval - 1);
-    }
-
-    @Test
-    public void removeTag_tagNotExists_throwsTagNotFoundException() throws Exception {
-        thrown.expect(TagNotFoundException.class);
-        defaultAddressBook.removeTag(tagEconomist);
     }
 
     @Test

--- a/test/java/seedu/addressbook/data/AddressBookTest.java
+++ b/test/java/seedu/addressbook/data/AddressBookTest.java
@@ -91,12 +91,9 @@ public class AddressBookTest {
 
     @Test
     public void addPerson_someTagsNotInTagList() throws Exception {
-        assertFalse(defaultAddressBook.containsTag(tagEconomist));
-        assertFalse(defaultAddressBook.containsTag(tagPrizeWinner));
+        assertFalse(isTagObjectInAddressBookList(tagEconomist, defaultAddressBook));
+        assertFalse(isTagObjectInAddressBookList(tagPrizeWinner, defaultAddressBook));
         defaultAddressBook.addPerson(davidElliot);
-        assertTrue(defaultAddressBook.containsTag(tagEconomist));
-        assertTrue(defaultAddressBook.containsTag(tagPrizeWinner));
-
         assertTrue(isTagObjectInAddressBookList(tagEconomist, defaultAddressBook));
         assertTrue(isTagObjectInAddressBookList(tagPrizeWinner, defaultAddressBook));
     }
@@ -117,7 +114,7 @@ public class AddressBookTest {
             // ignore expected exception
         }
 
-        assertFalse(defaultAddressBook.containsTag(tagPrizeWinner));
+        assertFalse(isTagObjectInAddressBookList(tagPrizeWinner, defaultAddressBook));
     }
 
     @Test
@@ -136,25 +133,6 @@ public class AddressBookTest {
 
         for (Person person : allPersons) {
             assertFalse(emptyAddressBook.containsPerson(person));
-        }
-    }
-
-    @Test
-    public void containsTag() throws Exception {
-        UniqueTagList tagsWhichShouldBeIn = new UniqueTagList(tagMathematician, tagScientist);
-        UniqueTagList tagsWHichShouldNotBeIn = new UniqueTagList(tagEconomist, tagPrizeWinner);
-
-        for (Tag tagWhichShouldBeIn : tagsWhichShouldBeIn) {
-            assertTrue(defaultAddressBook.containsTag(tagWhichShouldBeIn));
-        }
-        for (Tag tagWhichShouldNotBeIn : tagsWHichShouldNotBeIn) {
-            assertFalse(defaultAddressBook.containsTag(tagWhichShouldNotBeIn));
-        }
-
-        UniqueTagList allTags = new UniqueTagList(tagPrizeWinner, tagScientist, tagMathematician, tagEconomist);
-
-        for (Tag tag : allTags) {
-            assertFalse(emptyAddressBook.containsTag(tag));
         }
     }
 


### PR DESCRIPTION
Fixes #169 

Removed unused tag level methods in AddressBook: 
- addTag()
- removeTag()
- containsTag()

@yamgent @chao1995 With your unit test experiences, what are your thoughts on how tests that relied on containsTag() were handled?