### PR TITLE
Ensure java 9 compatibility #381

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: oraclejdk9
 
 script:
   - (cd test && ./runtests.sh) # I/O tests
@@ -18,4 +18,4 @@ deploy:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -7,7 +7,7 @@
 
 *Prerequisites*
 
-* JDK 8 or later
+* JDK 9 or later
 * IntelliJ IDE
 
 *Importing the project into IntelliJ*
@@ -16,7 +16,7 @@
 . Open IntelliJ (if you are not in the welcome screen, click `File` > `Close Project` to close the existing project dialog first)
 . Set up the correct JDK version
 .. Click `Configure` > `Project Defaults` > `Project Structure`
-.. If JDK 8 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 8.
+.. If JDK 9 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 9.
 .. Click `OK`.
 . Click `Import Project`
 . Locate the project directory and click `OK`

--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -30,8 +30,8 @@ public class UtilsTest {
         assertNotUnique("abc", "abc");
         assertNotUnique("abc", "", "abc", "ABC");
         assertNotUnique("", "abc", "a", "abc");
-        assertNotUnique(1, new Integer(1));
-        assertNotUnique(null, 1, new Integer(1));
+        assertNotUnique(1, Integer.valueOf(1));
+        assertNotUnique(null, 1, Integer.valueOf(1));
         assertNotUnique(null, null);
         assertNotUnique(null, "a", "b", null);
     }


### PR DESCRIPTION
Fixes #381 
```
The project currently runs on Java 8.

Since AddressBookL4 is already running on Java 9, this project should
be upgraded to run on Java 9 as well for consistency.

Since the project has been adjusted to be Java 9 compatible in #388,
let's update the DeveloperGuide to mention using Java 9 or later.

Travis currently builds the project using JDK 8. Since we are now
running on Java 9, let's update it to build the project using JDK 9
as well.

UtilsTest uses the Integer(int) constructor for its equality test,
which is deprecated from Java 9[1]. Since use of deprecated APIs is
considered bad practice, let's replace this with Integer.valueOf(int).

[1] https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-