### PR TITLE
docs: fix documentation

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -2,6 +2,7 @@
 :site-section: DeveloperGuide
 :imagesDir: images
 :stylesDir: stylesheets
+:experimental:
 
 == Setting up
 
@@ -16,8 +17,8 @@
 . Open IntelliJ (if you are not in the welcome screen, click `File` > `Close Project` to close the existing project dialog first)
 . Set up the correct JDK version
 .. Click `Configure` > `Project Defaults` > `Project Structure`
-.. If JDK 9 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 9.
-.. Click `OK`.
+.. If JDK 9 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 9
+.. Click `OK`
 . Click `Import Project`
 . Locate the project directory and click `OK`
 . Select `Create project from existing sources` and click `Next`
@@ -26,8 +27,8 @@
 . Click `Finish`
 . Add JUnit 4 to classpath
 .. Open any test file in `\test\java` and place your cursor over any `@Test` highlighted in red
-.. Press ALT+ENTER and select `Add 'JUnit4' to classpath`
-.. Select `Use 'JUnit4' from IntelliJ IDEA distribution` and click `OK`
+.. Press kbd:[ALT + ENTER] and select `Add 'JUnit4' to classpath`
+.. Select `junit:junit:4.12` and click `OK` (if `4.12` is not available, choose any `4.x` that is later than `4.12`)
 . Run all the tests (right-click the `test` folder, and click `Run 'All Tests'`)
 . Observe how some tests fail. That is because they try to access the test data from the wrong directory (the working directory is expected to be the root directory, but IntelliJ runs the test with `test\` as the working directory by default). To fix this issue:
 .. Go to `Run` -> `Edit Configurations...`
@@ -35,7 +36,7 @@
 .. Expand `Defaults`, and ensure that `JUnit` is selected
 .. Under `Configuration`, change the `Working directory` to the `addressbook-level2` folder
 .. Click `OK`
-. Run the tests again to ensure they all pass now.
+. Run the tests again to ensure they all pass now
 
 == Design
 
@@ -50,14 +51,14 @@ image::mainClassDiagram.png[]
 . Open a DOS window in the `test` folder
 . Run the `runtests.bat` script
 . If the script reports that there is no difference between `actual.txt` and `expected.txt`,
-the test has passed.
+the test has passed
 
 *Mac/Unix/Linux*
 
 . Open a terminal window in the `test` folder
 . Run the `runtests.sh` script
 . If the script reports that there is no difference between `actual.txt` and `expected.txt`,
-the test has passed.
+the test has passed
 
 === JUnit tests
 
@@ -66,7 +67,7 @@ the test has passed.
 === Troubleshooting test failures
 
 * Problem: How do I examine the exact differences between `actual.txt` and `expected.txt`? +
-Solution: You can use a diff/merge tool with a GUI e.g. WinMerge (on Windows)
+Solution: You can use a diff/merge tool with a GUI e.g. WinMerge (on Windows).
 
 * Problem: The two files look exactly the same, but the test script reports they are different. +
 Solution: This can happen because the line endings used by Windows is different from Unix-based

--- a/docs/LearningOutcomes.adoc
+++ b/docs/LearningOutcomes.adoc
@@ -20,7 +20,7 @@ toc::[]
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/objects/encapsulation/[se-edu/se-book: Design: OOP: Objects: Encapsulation]
+* https://se-edu.github.io/se-book/oop/objects/encapsulation/[se-edu/se-book: Paradigms: OOP: Objects: Encapsulation]
 
 === Exercise: Encapsulate `CommandResult` class members
 
@@ -33,7 +33,7 @@ Hide it so that it can only be accessed using methods provided.
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/classes/[se-edu/se-book: Design: OOP: Classes]
+* https://se-edu.github.io/se-book/oop/classes/[se-edu/se-book: Paradigms: OOP: Classes]
 
 === Exercise: Split `Address` into more classes
 
@@ -70,6 +70,7 @@ separate class named `Formatter`.
 === References
 
 * https://se-edu.github.io/se-book/errorHandling/exceptions/[se-edu/se-book: Error Handling: Exceptions]
+* https://se-edu.github.io/se-book/cppToJava/exceptions/[se-edu/se-book: C++ to Java: Exceptions]
 
 === Exercise: Handle 'file readonly' situation
 
@@ -85,8 +86,8 @@ in multiple `*Command` classes.
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/inheritance/[se-edu/se-book: Design: OOP: Inheritance]
-* https://se-edu.github.io/se-book/oopImplementation/inheritance/[se-edu/se-book: Implementation: OOP: Inheritance]
+* https://se-edu.github.io/se-book/oop/inheritance/[se-edu/se-book: Paradigms: OOP: Inheritance]
+* https://se-edu.github.io/se-book/cppToJava/inheritance/[se-edu/se-book: C++ to Java: Inheritance]
 
 === Exercise: Extract a `Contact` class
 
@@ -144,7 +145,8 @@ e.g. `Main.VERSION`, `Name.EXAMPLE`, `Utils.isAnyNull(...)`
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/classes/classLevelMembers/[se-edu/se-book: Design: OOP: Classes: Class-Level Members]
+* https://se-edu.github.io/se-book/oop/classes/classLevelMembers/[se-edu/se-book: Paradigms: OOP: Classes: Class-Level Members]
+* https://se-edu.github.io/se-book/cppToJava/classes/classLevelMembers/[se-edu/se-book: C++ to Java: Classes: Class-Level Members]
 
 === Exercise: Add class-level members
 
@@ -182,8 +184,7 @@ Contrast with these examples of _aggregration_ (empty diamond):
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/associations/composition/[se-edu/se-book: Design: OOP: Associations: Composition]
-* https://se-edu.github.io/se-book/oopImplementation/composition/[se-edu/se-book: Implementation: OOP: Composition]
+* https://se-edu.github.io/se-book/oop/associations/composition/[se-edu/se-book: Paradigms: OOP: Associations: Composition]
 
 '''''
 
@@ -193,8 +194,7 @@ The current design does not have any association classes.
 
 === References
 
-* https://se-edu.github.io/se-book/oopDesign/associations/associationClasses/[se-edu/se-book: Design: OOP: Associations: Association Classes]
-* https://se-edu.github.io/se-book/oopImplementation/associationClasses/[se-edu/se-book: Implementation: OOP: Association Classes]
+* https://se-edu.github.io/se-book/oop/associations/associationClasses/[se-edu/se-book: Paradigms: OOP: Associations: Association Classes]
 
 === Exercise: Add an Association Class `Tagging`
 
@@ -237,7 +237,7 @@ Note how there are many test classes in this code base that uses JUnit to implem
 
 * First, make sure you know how to run JUnit tests by running existing JUnit tests.
 Instructions are in the <<DeveloperGuide#junit-tests, Developer Guide>>.
-* Next, add a test to link:{repoURL}/test/java/seedu/addressbook/common/UtilsTest.java[`test/seedu/addressbook/common/UtilsTest.java`] to test the link:{repoURL}/src/seedu/addressbook/common/Utils.java[`seedu.addressbook.common.Utils#isAnyNull(Object...)`] method.
+* Next, add a test to link:{repoURL}/test/java/seedu/addressbook/common/UtilsTest.java[`test/seedu/addressbook/common/UtilsTest.java`] to test the link:{repoURL}/src/seedu/addressbook/common/Utils.java#L15[`seedu.addressbook.common.Utils#isAnyNull(Object...)`] method.
 
 '''''
 
@@ -256,7 +256,7 @@ It's recommended you do `[LO-JUnit]` before attempting TDD.
 [source,java]
 ----
 /**
-  * Returns true of the other name is very similar to this name.
+  * Returns true if the other name is very similar to this name.
   * Two names are considered similar if ...
   */
   public boolean isSimilar(Name other) { ... }

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -6,6 +6,7 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
+:experimental:
 
 This product is not meant for end-users and therefore there is no user-friendly installer.
 Please refer to the <<DeveloperGuide#setting-up, Setting up>> section to learn how to set up the project.
@@ -14,8 +15,8 @@ Please refer to the <<DeveloperGuide#setting-up, Setting up>> section to learn h
 
 *Using IntelliJ*
 
-. Find the project in the `Project Explorer` (usually located at the left side).
-.. If the `Project Explorer` is not visible, press ALT+1 for Windows/Linux, CMD+1 for macOS to open the `Project Explorer` tab.
+. Find the project in the `Project Explorer` (usually located at the left side)
+.. If the `Project Explorer` is not visible, press kbd:[ALT+1] for Windows/Linux, kbd:[CMD+1] for macOS to open the `Project Explorer` tab
 . Go to the `src` folder and locate the `Main` file
 . Right click the file and select `Run Main.main()`
 . The program now should run on the `Console` (usually located at the bottom side)
@@ -58,7 +59,7 @@ items with `...` after them can have multiple instances. Order of parameters are
 Put a `p` before the phone / email / address prefixes to mark it as `private`. `private` details can only
 be seen using the `viewall` command.
 
-Persons can have any number of tags (including 0)
+Persons can have any number of tags (including 0).
 ****
 
 Examples:
@@ -68,7 +69,7 @@ Examples:
 
 == Listing all persons : `list`
 
-Shows a list of all persons in the address book. +
+Shows a list of all persons, along with their non-private details, in the address book. +
 Format: `list`
 
 == Finding all persons containing any keyword in their name: `find`
@@ -168,16 +169,16 @@ There is no need to save manually.
 
 == Changing the save location
 
-Address book data are saved in a file called `addressbook.xml` in the project root folder.
+Address book data are saved in a file called `addressbook.txt` in the project root folder.
 You can change the location by specifying the file path as a program argument.
 
 Example:
 
-* `java seedu.addressbook.Main mydata.xml`
+* `java seedu.addressbook.Main mydata.txt`
 
 [NOTE]
 ====
-The file name must end in `.xml` for it to be acceptable to the program.
+The file name must end in `.txt` for it to be acceptable to the program.
 
 When running the program inside IntelliJ, you can set command line parameters
 before running the program.


### PR DESCRIPTION
Fixes #386.

```
In DeveloperGuide, the instructions to add JUnit 4 to class path
in IntelliJ are out of date. Let's fix it.

In UserGuide, the instructions for "Changing of save location" still
use the `.xml` file extension, when it has been updated to `.txt`
in #388. Let's fix it as well.

In LearningOutcome, there are some typos and incorrect links. Let's
fix them as well.
```