### PR TITLE
Fix runtests scripts proceeding on compilation error

### DIFF
--- a/test/runtests.bat
+++ b/test/runtests.bat
@@ -8,6 +8,11 @@ del actual.txt
 
 REM compile the code into the bin folder
 javac  -cp ..\src -Xlint:none -d ..\bin ..\src\seedu\addressbook\Main.java
+IF ERRORLEVEL 1 (
+    echo ********** BUILD FAILURE ********** 
+    exit /b 1
+)
+REM no error here, errorlevel == 0
 
 REM run the program, feed commands from input.txt file and redirect the output to the actual.txt
 java -classpath ..\bin seedu.addressbook.Main < input.txt > actual.txt

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -12,8 +12,12 @@ then
     rm actual.txt
 fi
 
-# compile the code into the bin folder
-javac -cp ../src -Xlint:none -d ../bin ../src/seedu/addressbook/Main.java
+# compile the code into the bin folder, terminates if error occurred
+if ! javac -cp ../src -Xlint:none -d ../bin ../src/seedu/addressbook/Main.java
+then
+    echo "********** BUILD FAILURE **********"
+    exit 1
+fi
 
 # run the program, feed commands from input.txt file and redirect the output to the actual.txt
 java -classpath ../bin seedu.addressbook.Main < input.txt > actual.txt


### PR DESCRIPTION
Similar fix in https://github.com/se-edu/addressbook-level1/pull/101
```
Runtests scripts compile the program under test, before executing the
tests. The tests always execute regardless of whether the compilation
succeeds or not.

If the program has compilation errors, the runtests scripts are
actually testing an older version of the program without the errors.
This results in misleading test results.

Let's teach the scripts to terminate immediately when the program fails
to compile.
```