### PR TITLE
ParserTest: Fix bug in String.format

### DIFF
--- a/test/java/seedu/addressbook/parser/ParserTest.java
+++ b/test/java/seedu/addressbook/parser/ParserTest.java
@@ -208,11 +208,11 @@ public class ParserTest {
             "add ",
             "add wrong args format",
             // no phone prefix
-            String.format("add $s $s e/$s a/$s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
+            String.format("add %s %s e/%s a/%s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
             // no email prefix
-            String.format("add $s p/$s $s a/$s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
+            String.format("add %s p/%s %s a/%s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
             // no address prefix
-            String.format("add $s p/$s e/$s $s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE)
+            String.format("add %s p/%s e/%s %s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE)
         };
         final String resultMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
         parseAndAssertIncorrectWithMessage(resultMessage, inputs);
@@ -229,7 +229,7 @@ public class ParserTest {
         final String invalidTagArg = "t/invalid_-[.tag";
 
         // address can be any string, so no invalid address
-        final String addCommandFormatString = "add $s $s $s a/" + Address.EXAMPLE;
+        final String addCommandFormatString = "add %s %s %s a/" + Address.EXAMPLE;
 
         // test each incorrect person data field argument individually
         final String[] inputs = {


### PR DESCRIPTION
**This is not a submission for an LO. It is a pull request for an actual bug fix.**

In the current implementation of ParserTest, parse_addCommandInvalidArgs_errorMessage and parse_addCommandInvalidPersonDataInArgs_errorMessge are implemented wrongly. Both used String.format with $s instead of %s. 

String.format actually does not format the string correctly with Name.EXAMPLE, Phone.EXAMPLE etc.
For example, 
[Line 237] String.format(addCommandFormatString, invalidName, validPhoneArg, validEmailArg) becomes "add $s $s $s a/123, some street". You can verify this by setting a breakpoint in the debugger. 
The expected behaviour should be "add []\[;] p/123456789 e/valid@e.mail a/123, some street.

All the tests are currently passing because these two methods are supposed to test for InvalidCommand, which returns the correct result despite a faulty test input.
On the other hand, parse_addCommandValidPersonData_parsedCorrectly works as intended as well because it generatesTestPerson then converts by concatenating strings, which subverts the bug too.