### PR TITLE
Parser: replace regular expressions with a simpler method #425

### DIFF
--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -29,9 +29,7 @@ import seedu.addressbook.data.exception.IllegalValueException;
  * Parses user input.
  */
 public class Parser {
-
-    public static final Pattern PERSON_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
-
+    
     public static final Pattern KEYWORDS_ARGS_FORMAT =
             Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
 
@@ -226,11 +224,11 @@ public class Parser {
      * @throws NumberFormatException the args string region is not a valid number
      */
     private int parseArgsAsDisplayedIndex(String args) throws ParseException, NumberFormatException {
-        final Matcher matcher = PERSON_INDEX_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
+        if (args.trim().isEmpty()) {
             throw new ParseException("Could not find index number to parse");
+        } else {
+            return Integer.parseInt(args.trim());
         }
-        return Integer.parseInt(matcher.group("targetIndex"));
     }
 
 

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -314,10 +314,7 @@ public class Parser {
      * @return true if item is valid, false otherwise.
      */
     private static boolean checkValidity (String item) {
-        if (item.isEmpty() || item.contains("/")) {
-            return false;
-        }
-        return true;
+        return (!item.isEmpty() && !item.contains("/"));
     }
 
     /**
@@ -420,7 +417,7 @@ public class Parser {
         }
 
         // keywords delimited by whitespace
-        final String[] keywords = args.trim().split(" ");;
+        final String[] keywords = args.trim().split(" ");
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         return new FindCommand(keywordSet);
     }

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -267,8 +267,12 @@ public class Parser {
      */
     private String extractTags(String[] tokenList) {
         StringBuilder sb = new StringBuilder();
+        boolean tokenFound = false;
         for (String token : tokenList) {
             if (token.contains("t/")) {
+                sb.append(token + " ");
+                tokenFound = true;
+            } else if (tokenFound && !token.contains("t/")) {
                 sb.append(token + " ");
             } else {
                 continue;

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -29,9 +29,6 @@ import seedu.addressbook.data.exception.IllegalValueException;
  * Parses user input.
  */
 public class Parser {
-    
-    public static final Pattern KEYWORDS_ARGS_FORMAT =
-            Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
 
     public static final Pattern PERSON_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
             Pattern.compile("(?<name>[^/]+)"
@@ -239,14 +236,13 @@ public class Parser {
      * @return the prepared command
      */
     private Command prepareFind(String args) {
-        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
+        if (args.trim().isEmpty()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindCommand.MESSAGE_USAGE));
         }
 
         // keywords delimited by whitespace
-        final String[] keywords = matcher.group("keywords").split("\\s+");
+        final String[] keywords = args.trim().split(" ");;
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         return new FindCommand(keywordSet);
     }

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 import seedu.addressbook.commands.AddCommand;
@@ -50,12 +51,7 @@ public class Parser {
             super(message);
         }
     }
-
-    /**
-     * Used for initial separation of command word and args.
-     */
-    public static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
-
+    
     /**
      * Parses user input into command for execution.
      *
@@ -63,13 +59,22 @@ public class Parser {
      * @return the command based on the user input
      */
     public Command parseCommand(String userInput) {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
+        StringTokenizer st = new StringTokenizer(userInput.trim());
+
+        //Retrieve command word
+        String commandWord;
+        if (st.hasMoreElements()) {
+            commandWord = st.nextToken();
+        } else {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        //Retrieve arguments
+        StringBuilder sb = new StringBuilder();
+        while (st.hasMoreElements()) {
+            sb.append(st.nextToken() + " ");
+        }
+        String arguments = sb.toString();
 
         switch (commandWord) {
 

--- a/src/seedu/addressbook/storage/AddressBookDecoder.java
+++ b/src/seedu/addressbook/storage/AddressBookDecoder.java
@@ -1,13 +1,12 @@
 package seedu.addressbook.storage;
 
-import static seedu.addressbook.parser.Parser.PERSON_DATA_ARGS_FORMAT;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.addressbook.data.AddressBook;
 import seedu.addressbook.data.exception.IllegalValueException;
@@ -24,6 +23,13 @@ import seedu.addressbook.storage.StorageFile.StorageOperationException;
  * Decodes the storage data file into an {@code AddressBook} object.
  */
 public class AddressBookDecoder {
+
+    public static final Pattern PERSON_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
+            Pattern.compile("(?<name>[^/]+)"
+                    + " (?<isPhonePrivate>p?)p/(?<phone>[^/]+)"
+                    + " (?<isEmailPrivate>p?)e/(?<email>[^/]+)"
+                    + " (?<isAddressPrivate>p?)a/(?<address>[^/]+)"
+                    + "(?<tagArguments>(?: t/[^/]+)*)"); // variable number of tags
 
     /**
      * Decodes {@code encodedAddressBook} into an {@code AddressBook} containing the decoded persons.


### PR DESCRIPTION
Fixes #425 

Regex is being used to parse commands currently. 

In order to simplify the understanding of Parser for students, let's replace regex with simpler methods in Parser.