### PR TITLE
Utils#isAnyNull: Check for null on entire object

### DIFF
--- a/src/seedu/addressbook/common/Utils.java
+++ b/src/seedu/addressbook/common/Utils.java
@@ -13,6 +13,9 @@ public class Utils {
      * Returns true if any of the given items are null.
      */
     public static boolean isAnyNull(Object... items) {
+        if (items == null) {
+            return false;
+        }
         for (Object item : items) {
             if (item == null) {
                 return true;

--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -36,6 +36,27 @@ public class UtilsTest {
         assertNotUnique(null, "a", "b", null);
     }
 
+    @Test
+    public void isAnyNull() {
+        // no items
+        assertFalse(Utils.isAnyNull());
+
+        // varargs array that is null (i.e. no array)
+        assertFalse(Utils.isAnyNull((Object[]) null));
+
+        // one item which is null (i.e. an array with one null item)
+        assertTrue(Utils.isAnyNull((Object) null));
+
+        // at least one item, none of which are null
+        assertFalse(Utils.isAnyNull("A"));
+        assertFalse(Utils.isAnyNull("A", ""));
+        assertFalse(Utils.isAnyNull(1, 2, "C"));
+
+        // at least one item, some of which are null
+        assertTrue(Utils.isAnyNull(null, 1));
+        assertTrue(Utils.isAnyNull("A", null, "C"));
+    }
+
     private void assertAreUnique(Object... objects) {
         assertTrue(Utils.elementsAreUnique(Arrays.asList(objects)));
     }


### PR DESCRIPTION
Currently, isAnyNull assumes that the `items` varargs is not null.
However, this is not necessarily the case. It can be the case that `isAnyNull(null)` is called. If the varargs is null, the function should return false, since there is nothing to be examined. Presently, the code will simply crash with a NullPointerException if null is passed in as an argument.
Hence, the proposed changes add checks to ensure that the varargs object is not null.

Along with the changes, I have created unit tests to protect against regressions of this issue.

This proposed change fixes #426.