### PR TITLE
ParserTest: Fix incorrectly formatted command string

### DIFF
--- a/test/java/seedu/addressbook/parser/ParserTest.java
+++ b/test/java/seedu/addressbook/parser/ParserTest.java
@@ -208,11 +208,11 @@ public class ParserTest {
             "add ",
             "add wrong args format",
             // no phone prefix
-            String.format("add $s $s e/$s a/$s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
+            String.format("add %s %s e/%s a/%s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
             // no email prefix
-            String.format("add $s p/$s $s a/$s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
+            String.format("add %s p/%s %s a/%s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE),
             // no address prefix
-            String.format("add $s p/$s e/$s $s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE)
+            String.format("add %s p/%s e/%s %s", Name.EXAMPLE, Phone.EXAMPLE, Email.EXAMPLE, Address.EXAMPLE)
         };
         final String resultMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
         parseAndAssertIncorrectWithMessage(resultMessage, inputs);
@@ -229,7 +229,7 @@ public class ParserTest {
         final String invalidTagArg = "t/invalid_-[.tag";
 
         // address can be any string, so no invalid address
-        final String addCommandFormatString = "add $s $s $s a/" + Address.EXAMPLE;
+        final String addCommandFormatString = "add %s %s %s a/" + Address.EXAMPLE;
 
         // test each incorrect person data field argument individually
         final String[] inputs = {


### PR DESCRIPTION
Currently, the test methods
parse_addCommandInvalidPersonDataInArgs_errorMessge() and
parse_addCommandInvalidArgs_errorMessage() use an incorrectly formatted
command string. They attempt to format commands with `$s`.

This `$s` is not recognized by Java’s String#format(…), thus the
command is not formatted as expected, but instead simply left untouched.
The tests currently pass, however, because `$s` achieves the purpose of
being an invalid command string. However, this is clearly not the
intention of the test case, which is designed to simulate with sample
names, phones and emails.

To fix the bug in the test, let’s change the occurrences of `$s` to `%s`.

This PR supersedes #431 (because I accidentally deleted the fork and can't push to the PR anymore -_-)