### PR TITLE
[#503]Migration to JDK11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: oraclejdk11
 
 install:
   - ./config/travis/download_gradle_wrapper.sh
@@ -17,8 +17,3 @@ deploy:
   script: ./config/travis/deploy_github_pages.sh
   on:
     branch: master
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -8,7 +8,7 @@
 
 *Prerequisites*
 
-* JDK 8
+* JDK 11
 * IntelliJ IDE
 
 *Importing the project into IntelliJ*
@@ -17,7 +17,7 @@
 . Open IntelliJ (if you are not in the welcome screen, click `File` > `Close Project` to close the existing project dialog first)
 . Set up the correct JDK version
 .. Click `Configure` > `Project Defaults` > `Project Structure`
-.. If JDK 8 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 8
+.. If JDK 11 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 11
 .. Click `OK`
 . Click `Import Project`
 . Locate the project directory and click `OK`


### PR DESCRIPTION
For consistency with the other ABs, let's update AB-2 to JDK11.
Fortunately the codebase can be ported without any changes.

[1/2] Updated travis to use Oracle JDK 11
[2/2] Updated references to JDK 8 to JDK 11 in the Developer Guide.