### PR TITLE
Migrate to checkstyle 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 
 script:
   - (cd test && ./runtests.sh) # I/O tests
-  - ./gradlew -b build.gradle.txt clean test # JUnit tests
+  - ./gradlew -b build.gradle.txt clean test checkstyleMain checkstyleTest # JUnit test and runs checkstyle
   - ./gradlew -b build.gradle.txt asciidoctor # Documentation
 
 deploy:

--- a/build.gradle.txt
+++ b/build.gradle.txt
@@ -13,7 +13,7 @@ repositories {
 }
 
 checkstyle {
-    toolVersion = '7.1.2'
+    toolVersion = '8.1'
 }
 
 sourceSets {
@@ -82,4 +82,4 @@ task copyStylesheets(type: Copy) {
 }
 asciidoctor.dependsOn copyStylesheets
 
-defaultTasks 'clean', 'test', 'asciidoctor'
+defaultTasks 'clean', 'test', 'asciidoctor', 'checkstyleMain', 'checkstyleTest'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     This configuration file enforces rules for a modified version of the module's code standard at
@@ -25,13 +25,10 @@
     <property name="message" value='TODO is preferred to FIXME."' />
   </module>
 
-
-  <!-- Required to allow exceptions in code style -->
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
-    <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
-    <property name="checkFormat" value="$1"/>
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
+
 
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">
@@ -39,23 +36,57 @@
     <!-- Required for SuppressionCommentFilter to work -->
     <module name="FileContentsHolder"/>
 
+    <!-- Required to allow exceptions in code style -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+      <property name="checkFormat" value="$1"/>
+    </module>
+
     <!--
     IMPORT CHECKS
     -->
 
-    <module name="RedundantImport">
-      <!-- Checks for redundant import statements. -->
-      <property name="severity" value="error"/>
+    <!-- Checks the ordering of import statements follow the rules that the default Eclipse formatter uses.
+    The order rule "STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE" consists of:
+      1. STATIC: static imports
+      2. STANDARD_JAVA_PACKAGE: standard java/javax imports
+      3. SPECIAL_IMPORTS: defined as org imports
+      4. THIRD_PARTY_PACKAGE: defined as com imports
+    -->
+    <module name="CustomImportOrder">
+        <property name="customImportOrderRules"
+            value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
+        <property name="specialImportsRegExp" value="^org\."/>
+        <property name="thirdPartyPackageRegExp" value="^com\."/>
+        <property name="sortImportsInGroupAlphabetically" value="true"/>
     </module>
 
-    <module name="AvoidStarImport">
-      <property name="allowClassImports" value="false"/>
-      <property name="allowStaticMemberImports" value="false"/>
-    </module>
+    <!-- Checks for redundant import statements.
+    An import statement is redundant if:
+      * It is a duplicate of another import. This is, when a class is imported more than once.
+      * The class non-statically imported is from the java.lang package, e.g. importing java.lang.String.
+      * The class non-statically imported is from the same package as the current package.
+    -->
+    <module name="RedundantImport"/>
+
+    <!-- Checks for unused import statements.
+    An import statement is unused if:
+      It's not referenced in the file.
+    -->
+    <module name="UnusedImports"/>
+
+    <module name="AvoidStarImport"/>
 
     <!--
     NAMING CHECKS
     -->
+
+    <!-- Validate abbreviations (consecutive capital letters) length in identifier name -->
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="1"/>
+    </module>
 
     <module name="PackageName">
       <!-- Validates identifiers for package names against the supplied expression. -->
@@ -63,51 +94,39 @@
       <property name="severity" value="warning"/>
     </module>
 
-    <module name="TypeNameCheck">
+    <module name="TypeName">
       <!-- Validates static, final fields against the expression "^[A-Z][a-zA-Z0-9]*$". -->
       <metadata name="altname" value="TypeName"/>
       <property name="severity" value="warning"/>
     </module>
 
-    <module name="ConstantNameCheck">
+    <module name="ConstantName">
       <!-- Validates non-private, static, final fields against the expression "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
       <metadata name="altname" value="ConstantName"/>
-      <property name="applyToPublic" value="true"/>
-      <property name="applyToProtected" value="true"/>
-      <property name="applyToPackage" value="true"/>
       <property name="applyToPrivate" value="false"/>
       <message key="name.invalidPattern"
                value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
       <property name="severity" value="warning"/>
     </module>
 
-    <module name="StaticVariableNameCheck">
+    <module name="StaticVariableName">
       <!-- Validates static, non-final fields against the supplied expression. -->
       <metadata name="altname" value="StaticVariableName"/>
-      <property name="applyToPublic" value="true"/>
-      <property name="applyToProtected" value="true"/>
-      <property name="applyToPackage" value="true"/>
-      <property name="applyToPrivate" value="true"/>
       <property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
       <property name="severity" value="warning"/>
     </module>
 
-    <module name="MemberNameCheck">
+    <module name="MemberName">
       <!-- Validates non-static members against the supplied expression. -->
       <metadata name="altname" value="MemberName"/>
-      <property name="applyToPublic" value="true"/>
-      <property name="applyToProtected" value="true"/>
-      <property name="applyToPackage" value="true"/>
-      <property name="applyToPrivate" value="true"/>
       <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
       <property name="severity" value="warning"/>
     </module>
 
-    <module name="MethodNameCheck">
+    <module name="MethodName">
       <!-- Validates identifiers for method names against the supplied expression. -->
       <metadata name="altname" value="MethodName"/>
-      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*|_+[A-Z]+(_[A-Z]+)*_+$"/>
-      <property name="severity" value="warning"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]+){0,2}$"/>
     </module>
 
     <module name="ParameterName">
@@ -130,10 +149,18 @@
     LENGTH and CODING CHECKS
     -->
 
+    <!-- Checks that array type declarations follow Java Style
+      Java style: public static void main(String[] args) // Allowed
+      C style:    public static void main(String args[]) // Not allowed
+    -->
+    <module name="ArrayTypeStyle"/>
+
+    <!-- Checks if a catch block is empty and does not contain any comments. -->
+    <module name="EmptyCatchBlock"/>
+
     <module name="LineLength">
       <!-- Checks if a line is too long. -->
       <property name="max" value="120"/>
-      <property name="severity" value="error"/>
     </module>
 
     <module name="LeftCurly">
@@ -158,16 +185,13 @@
         else
       </pre>
       -->
-      <property name="option" value="same"/>
       <property name="severity" value="warning"/>
     </module>
 
     <!-- Checks for braces around loop blocks -->
     <module name="NeedBraces">
-      <property name="severity" value="warning"/>
-      <property name="tokens" value="LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, LITERAL_IF, LITERAL_ELSE"/>
       <!--
-      if (true) return 1; // Allowed
+      if (true) return 1; // Not allowed
 
       if (true) { return 1; } // Not allowed
 
@@ -179,13 +203,15 @@
         return 1; // Not allowed
       -->
       <property name="allowEmptyLoopBody" value="true"/>
-      <property name="allowSingleLineStatement" value="true"/>
     </module>
 
-    <module name="UpperEll">
-      <!-- Checks that long constants are defined with an upper ell.-->
-      <property name="severity" value="error"/>
-    </module>
+    <!-- Checks that each variable declaration is in its own statement and on its own line. -->
+    <module name="MultipleVariableDeclarations"/>
+
+    <module name="OneStatementPerLine"/>
+
+    <!-- Checks that long constants are defined with an upper ell.-->
+    <module name="UpperEll" />
 
     <module name="FallThrough">
       <!-- Warn about falling through to the next case statement.  Similar to
@@ -195,13 +221,33 @@
       -->
       <property name="reliefPattern"
        value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
-      <property name="severity" value="error"/>
     </module>
 
+    <module name="MissingSwitchDefault"/>
+
+    <!-- Checks that Class variables should never be declared public. -->
+    <module name="VisibilityModifier">
+      <property name="protectedAllowed" value="true"/>
+      <property name="allowPublicFinalFields" value="true"/>
+      <property name="ignoreAnnotationCanonicalNames" value="RegisterExtension, TempDir"/>
+    </module>
 
     <!--
-    MODIFIERS CHECKS
+    ORDER CHECKS
     -->
+
+    <!-- Checks that the order of at-clauses follows the tagOrder default property value order.
+         @author, @version, @param, @return, @throws, @exception, @see, @since, @serial, @serialField, @serialData, @deprecated
+    -->
+    <module name="AtclauseOrder"/>
+
+    <!-- Checks if the Class and Interface declarations is organized in this order
+      1. Class (static) variables. Order: public, protected, package level (no access modifier), private.
+      2. Instance variables. Order: public, protected, package level (no access modifier), private.
+      3. Constructors
+      4. Methods
+    -->
+    <module name ="DeclarationOrder"/>
 
     <module name="ModifierOrder">
       <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
@@ -211,10 +257,14 @@
         -->
     </module>
 
+    <module name="OverloadMethodsDeclarationOrder"/>
 
     <!--
     WHITESPACE CHECKS
     -->
+
+    <!-- Checks that comments are indented relative to their position in the code -->
+    <module name="CommentsIndentation"/>
 
     <module name="WhitespaceAround">
       <!-- Checks that various tokens are surrounded by whitespace.
@@ -238,7 +288,6 @@
       <property name="allowEmptyLoops" value="true" />
       <!-- Allow empty lambdas e.g. () -> {} -->
       <property name="allowEmptyLambdas" value="true" />
-      <property name="severity" value="error"/>
     </module>
 
     <module name="WhitespaceAfter">
@@ -251,7 +300,6 @@
       <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
         UNARY_PLUS"/>
       <property name="allowLineBreaks" value="true"/>
-      <property name="severity" value="error"/>
     </module>
 
     <!-- No trailing whitespace -->
@@ -259,6 +307,39 @@
       <property name="format" value="[ \t]+$"/>
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Trailing whitespace"/>
+    </module>
+
+    <module name="OperatorWrap">
+      <!-- Checks that the non-assignment type operator is at the next line in a line wrap.
+           This includes "?", ":", "==", "!=", "/", "+", "-", "*", "%", ">>", ">>>",
+           ">=", ">", "<<", "<=", "<", "^", "|", "||", "&", "&&", "instanceof",
+           "&" when used in a generic upper or lower bounds constraints,
+             e.g. <T extends Foo & Bar>
+           "::" when used as a reference to a method or constructor without arguments.
+             e.g. String::compareToIgnoreCase
+      -->
+      <property name="tokens" value="QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD, SR, BSR,
+        GE, GT, SL, LE, LT, BXOR, BOR, LOR, BAND, LAND, LITERAL_INSTANCEOF, TYPE_EXTENSION_AND, METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="OperatorWrap">
+      <!-- Checks that the assignment type operator is at the previous end of line in a line wrap.
+           This includes "=", "/=", "+=", "-=", "*=", "%=", ">>=", ">>>=", "<<=", "^=", "&=".
+      -->
+      <property name="tokens" value="ASSIGN, DIV_ASSIGN, PLUS_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN,
+        SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN"/>
+      <property name="option" value="eol"/>
+    </module>
+
+    <module name="SeparatorWrap">
+      <!-- Checks that the ".", "@" is at the next line in a line wrap. -->
+      <property name="tokens" value="DOT, AT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- Checks that the ",", "]", "[", "...", ";", "(" is at the previous end of line in a line wrap. -->
+      <property name="tokens" value="COMMA, RBRACK, ARRAY_DECLARATOR, ELLIPSIS, SEMI, LPAREN"/>
+      <property name="option" value="eol"/>
     </module>
 
     <module name="Indentation">
@@ -269,12 +350,74 @@
       <!-- Checks that there is no whitespace before various unary operators. Linebreaks are allowed. -->
       <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
       <property name="allowLineBreaks" value="true"/>
-      <property name="severity" value="error"/>
     </module>
 
     <module name="ParenPad">
       <!-- Checks that there is no whitespace before close parenthesis or after open parenthesis. -->
       <property name="severity" value="warning"/>
+    </module>
+
+    <!-- Checks that non-whitespace characters are separated by no more than one whitespace character.
+         a = 1; // Allowed
+         a  = 1; // Not allowed (more than one space before =)
+    -->
+    <module name="SingleSpaceSeparator">
+      <!-- Validate whitespace surrounding comments as well.
+
+           a = 1; // Allowed (single space before start of comment)
+           a = 1; /* Allowed (single space before start of comment) */
+           /* Allowed (single space after end of comment) */ a = 1;
+           a = 1;  // Not allowed (more than one space before start of comment)
+           a = 1;  /* Not allowed (more than one space before start of comment) */
+           /* Not allowed (more than one space after end of comment) */  a = 1;
+
+           This doesn't validate whitespace within comments so a comment /* like  this */ is allowed.
+      -->
+      <property name="validateComments" value="true"/>
+    </module>
+
+    <!--
+    JAVADOC CHECKS
+    -->
+
+    <!-- Checks that every class, enumeration and interface have a header comment. -->
+    <module name="JavadocType">
+      <property name="allowMissingParamTags" value="true"/>
+    </module>
+
+    <!-- Checks that every public method (excluding getters, setters and constructors) has a header comment. -->
+    <module name="JavadocMethod">
+      <!-- Checks public methods that have more than 1 line of code.
+        Single line of code methods are often due to refactor for readability.
+      -->
+      <property name="minLineCount" value="1"/>
+      <property name="allowedAnnotations" value="Override, Test, BeforeAll, BeforeEach, AfterAll, AfterEach, Subscribe"/>
+      <property name="scope" value="public"/>
+      <property name="allowUndeclaredRTE" value="true"/>
+      <property name="allowThrowsTagsForSubclasses" value="true"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingThrowsTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="ignoreMethodNamesRegex" value="(set.*|get.*)"/>
+      <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
+    </module>
+    <!-- Checks that every non-trivial private method (excluding getters, setters and constructors) has a header comment. -->
+    <module name="JavadocMethod">
+      <!-- Checks private methods that have more than 3 lines of code.
+        We define methods that have more than 3 lines of code as non-trivial.
+      -->
+      <property name="minLineCount" value="3"/>
+      <property name="allowedAnnotations" value="Override, Test, BeforeAll, BeforeEach, AfterAll, AfterEach, Subscribe"/>
+      <property name="scope" value="private"/>
+      <property name="allowUndeclaredRTE" value="true"/>
+      <property name="allowThrowsTagsForSubclasses" value="true"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingThrowsTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="ignoreMethodNamesRegex" value="(set.*|get.*)"/>
+      <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
     </module>
 
   </module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress checks="JavadocType" files=".*Test\.java"/>
+</suppressions>

--- a/src/seedu/addressbook/Main.java
+++ b/src/seedu/addressbook/Main.java
@@ -105,7 +105,7 @@ public class Main {
      * @param command user command
      * @return result of the command
      */
-    private CommandResult executeCommand(Command command)  {
+    private CommandResult executeCommand(Command command) {
         try {
             command.setData(addressBook, lastShownList);
             CommandResult result = command.execute();

--- a/src/seedu/addressbook/commands/Command.java
+++ b/src/seedu/addressbook/commands/Command.java
@@ -1,12 +1,12 @@
 package seedu.addressbook.commands;
 
-import seedu.addressbook.common.Messages;
-import seedu.addressbook.data.AddressBook;
-import seedu.addressbook.data.person.ReadOnlyPerson;
+import static seedu.addressbook.ui.TextUi.DISPLAYED_INDEX_OFFSET;
 
 import java.util.List;
 
-import static seedu.addressbook.ui.TextUi.DISPLAYED_INDEX_OFFSET;
+import seedu.addressbook.common.Messages;
+import seedu.addressbook.data.AddressBook;
+import seedu.addressbook.data.person.ReadOnlyPerson;
 
 /**
  * Represents an executable command.
@@ -39,7 +39,7 @@ public class Command {
     /**
      * Executes the command and returns the result.
      */
-    public CommandResult execute(){
+    public CommandResult execute() {
         throw new UnsupportedOperationException("This method is to be implemented by child classes");
     };
 

--- a/src/seedu/addressbook/commands/CommandResult.java
+++ b/src/seedu/addressbook/commands/CommandResult.java
@@ -1,9 +1,9 @@
 package seedu.addressbook.commands;
 
-import seedu.addressbook.data.person.ReadOnlyPerson;
-
 import java.util.List;
 import java.util.Optional;
+
+import seedu.addressbook.data.person.ReadOnlyPerson;
 
 /**
  * Represents the result of a command execution.

--- a/src/seedu/addressbook/commands/ListCommand.java
+++ b/src/seedu/addressbook/commands/ListCommand.java
@@ -1,9 +1,8 @@
 package seedu.addressbook.commands;
 
-import seedu.addressbook.data.person.ReadOnlyPerson;
-
 import java.util.List;
 
+import seedu.addressbook.data.person.ReadOnlyPerson;
 
 /**
  * Lists all persons in the address book to the user.

--- a/src/seedu/addressbook/common/Messages.java
+++ b/src/seedu/addressbook/common/Messages.java
@@ -11,8 +11,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSON_NOT_IN_ADDRESSBOOK = "Person could not be found in address book";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE = "Launch command format: " +
-            "java seedu.addressbook.Main [STORAGE_FILE_PATH]";
+    public static final String MESSAGE_PROGRAM_LAUNCH_ARGS_USAGE = "Launch command format: "
+            + "java seedu.addressbook.Main [STORAGE_FILE_PATH]";
     public static final String MESSAGE_WELCOME = "Welcome to your Address Book!";
     public static final String MESSAGE_USING_STORAGE_FILE = "Using storage file : %1$s";
 }

--- a/src/seedu/addressbook/data/person/Name.java
+++ b/src/seedu/addressbook/data/person/Name.java
@@ -1,9 +1,9 @@
 package seedu.addressbook.data.person;
 
-import seedu.addressbook.data.exception.IllegalValueException;
-
 import java.util.Arrays;
 import java.util.List;
+
+import seedu.addressbook.data.exception.IllegalValueException;
 
 /**
  * Represents a Person's name in the address book.

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -21,6 +21,9 @@ import seedu.addressbook.data.person.ReadOnlyPerson;
  */
 public class TextUi {
 
+    /** Offset required to convert between 1-indexing and 0-indexing.  */
+    public static final int DISPLAYED_INDEX_OFFSET = 1;
+
     /** A decorative prefix added to the beginning of lines printed by AddressBook */
     private static final String LINE_PREFIX = "|| ";
 
@@ -31,10 +34,6 @@ public class TextUi {
 
     /** Format of indexed list item */
     private static final String MESSAGE_INDEXED_LIST_ITEM = "\t%1$d. %2$s";
-
-
-    /** Offset required to convert between 1-indexing and 0-indexing.  */
-    public static final int DISPLAYED_INDEX_OFFSET = 1;
 
     /** Format of a comment input line. Comment lines are silently consumed when reading user input. */
     private static final String COMMENT_LINE_FORMAT_REGEX = "#.*";
@@ -91,7 +90,11 @@ public class TextUi {
         return fullInputLine;
     }
 
-
+    /**
+     * Generates and prints the welcome message upon the start of the application.
+     * @param version current version of the application.
+     * @param storageFilePath path to the storage file being used.
+     */
     public void showWelcomeMessage(String version, String storageFilePath) {
         String storageFileInfo = String.format(MESSAGE_USING_STORAGE_FILE, storageFilePath);
         showToUser(

--- a/test/java/seedu/addressbook/commands/FindCommandTest.java
+++ b/test/java/seedu/addressbook/commands/FindCommandTest.java
@@ -23,7 +23,7 @@ public class FindCommandTest {
     @Test
     public void execute() throws IllegalValueException {
         //same word, same case: matched
-        assertFindCommandBehavior(new String[]{"Amy"}, Arrays.asList(td.amy));
+        assertFindCommandBehavior(new String[]{"Amy"}, Arrays.asList(td.getAmy()));
 
         //same word, different case: not matched
         assertFindCommandBehavior(new String[]{"aMy"}, Collections.emptyList());
@@ -33,10 +33,10 @@ public class FindCommandTest {
 
         //multiple words: matched
         assertFindCommandBehavior(new String[]{"Amy", "Bill", "Candy", "Destiny"},
-                Arrays.asList(td.amy, td.bill, td.candy));
+                Arrays.asList(td.getAmy(), td.getBill(), td.getCandy()));
 
         //repeated keywords: matched
-        assertFindCommandBehavior(new String[]{"Amy", "Amy"}, Arrays.asList(td.amy));
+        assertFindCommandBehavior(new String[]{"Amy", "Amy"}, Arrays.asList(td.getAmy()));
 
         //Keyword matching a word in address: not matched
         assertFindCommandBehavior(new String[]{"Clementi"}, Collections.emptyList());
@@ -53,6 +53,11 @@ public class FindCommandTest {
         assertEquals(Command.getMessageForPersonListShownSummary(expectedPersonList), result.feedbackToUser);
     }
 
+    /**
+     * Factory method that creates and returns a {@code FindCommand}.
+     * @param keywords list of keywords to search for.
+     * @return an instance of {@FindCommand} that searches the test AddressBook.
+     */
     private FindCommand createFindCommand(String[] keywords) {
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         FindCommand command = new FindCommand(keywordSet);

--- a/test/java/seedu/addressbook/commands/ViewCommandTest.java
+++ b/test/java/seedu/addressbook/commands/ViewCommandTest.java
@@ -28,7 +28,7 @@ public class ViewCommandTest {
     private AddressBook emptyAddressBook = TestUtil.createAddressBook();
     private List<ReadOnlyPerson> emptyPersonList = Collections.emptyList();
     private List<ReadOnlyPerson> listWithAllTypicalPersons = Arrays.asList(td.getTypicalPersons());
-    private List<ReadOnlyPerson> listWithSomeTypicalPersons = Arrays.asList(td.amy, td.candy, td.dan);
+    private List<ReadOnlyPerson> listWithSomeTypicalPersons = Arrays.asList(td.getAmy(), td.getCandy(), td.getDan());
 
     @Test
     public void execute_invalidIndex_returnsInvalidIndexMessage() {
@@ -50,8 +50,7 @@ public class ViewCommandTest {
                                              new Email("some@hey.go", true),
                                              new Address("nus", false),
                                              Collections.emptySet());
-        List<ReadOnlyPerson> listWithExtraPerson
-                = new ArrayList<ReadOnlyPerson>(listWithAllTypicalPersons);
+        List<ReadOnlyPerson> listWithExtraPerson = new ArrayList<ReadOnlyPerson>(listWithAllTypicalPersons);
         listWithExtraPerson.add(stranger);
 
         // empty addressbook

--- a/test/java/seedu/addressbook/common/UtilsTest.java
+++ b/test/java/seedu/addressbook/common/UtilsTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/test/java/seedu/addressbook/data/AddressBookTest.java
+++ b/test/java/seedu/addressbook/data/AddressBookTest.java
@@ -25,6 +25,7 @@ import seedu.addressbook.data.person.UniquePersonList.PersonNotFoundException;
 import seedu.addressbook.data.tag.Tag;
 
 public class AddressBookTest {
+
     private Tag tagPrizeWinner;
     private Tag tagScientist;
     private Tag tagMathematician;
@@ -41,22 +42,22 @@ public class AddressBookTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        tagPrizeWinner   = new Tag("prizewinner");
-        tagScientist     = new Tag("scientist");
+        tagPrizeWinner = new Tag("prizewinner");
+        tagScientist = new Tag("scientist");
         tagMathematician = new Tag("mathematician");
-        tagEconomist     = new Tag("economist");
+        tagEconomist = new Tag("economist");
 
-        aliceBetsy     = new Person(new Name("Alice Betsy"),
-                                    new Phone("91235468", false),
-                                    new Email("alice@nushackers.org", false),
-                                    new Address("8 Computing Drive, Singapore", false),
-                                    Collections.singleton(tagMathematician));
+        aliceBetsy = new Person(new Name("Alice Betsy"),
+                                new Phone("91235468", false),
+                                new Email("alice@nushackers.org", false),
+                                new Address("8 Computing Drive, Singapore", false),
+                                Collections.singleton(tagMathematician));
 
-        bobChaplin     = new Person(new Name("Bob Chaplin"),
-                                    new Phone("94321500", false),
-                                    new Email("bob@nusgreyhats.org", false),
-                                    new Address("9 Computing Drive", false),
-                                    Collections.singleton(tagMathematician));
+        bobChaplin = new Person(new Name("Bob Chaplin"),
+                                new Phone("94321500", false),
+                                new Email("bob@nusgreyhats.org", false),
+                                new Address("9 Computing Drive", false),
+                                Collections.singleton(tagMathematician));
 
         charlieDouglas = new Person(new Name("Charlie Douglas"),
                                     new Phone("98751365", false),
@@ -64,11 +65,11 @@ public class AddressBookTest {
                                     new Address("10 Science Drive", false),
                                     Collections.singleton(tagScientist));
 
-        davidElliot    = new Person(new Name("David Elliot"),
-                                    new Phone("84512575", false),
-                                    new Email("douglas@nuscomputing.com", false),
-                                    new Address("11 Arts Link", false),
-                                    new HashSet<>(Arrays.asList(tagEconomist, tagPrizeWinner)));
+        davidElliot = new Person(new Name("David Elliot"),
+                                 new Phone("84512575", false),
+                                 new Email("douglas@nuscomputing.com", false),
+                                 new Address("11 Arts Link", false),
+                                 new HashSet<>(Arrays.asList(tagEconomist, tagPrizeWinner)));
 
         emptyAddressBook = new AddressBook();
         defaultAddressBook = new AddressBook(new UniquePersonList(aliceBetsy, bobChaplin));

--- a/test/java/seedu/addressbook/parser/ParserTest.java
+++ b/test/java/seedu/addressbook/parser/ParserTest.java
@@ -256,7 +256,7 @@ public class ParserTest {
     }
 
     @Test
-    public void parse_addCommandDuplicateTags_merged() throws IllegalValueException {
+    public void parse_addCommandDuplicateTags_merged() {
         final Person testPerson = generateTestPerson();
         String input = convertPersonToAddCommandString(testPerson);
         for (Tag tag : testPerson.getTags()) {
@@ -268,6 +268,10 @@ public class ParserTest {
         assertEquals(result.getPerson(), testPerson);
     }
 
+    /**
+     * Generates an instance of a {@code Person} from valid test data.
+     * @return an instance of a {@code Person}.
+     */
     private static Person generateTestPerson() {
         try {
             return new Person(
@@ -282,6 +286,11 @@ public class ParserTest {
         }
     }
 
+    /**
+     * Generates an add command from a {@code ReadOnlyPerson}.
+     * @param person whose data will be filled into the string.
+     * @return a string describing an {@code AddCommand}.
+     */
     private static String convertPersonToAddCommandString(ReadOnlyPerson person) {
         String addCommand = "add "
                 + person.getName().fullName

--- a/test/java/seedu/addressbook/storage/StorageFileTest.java
+++ b/test/java/seedu/addressbook/storage/StorageFileTest.java
@@ -1,6 +1,9 @@
 package seedu.addressbook.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.addressbook.util.TestUtil.assertFileDoesNotExist;
+import static seedu.addressbook.util.TestUtil.assertTextFilesEqual;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -21,16 +24,12 @@ import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.tag.Tag;
 import seedu.addressbook.storage.StorageFile.StorageOperationException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.addressbook.util.TestUtil.assertTextFilesEqual;
-import static seedu.addressbook.util.TestUtil.assertFileDoesNotExist;
-
 public class StorageFileTest {
-    private static final String TEST_DATA_FOLDER = "test/data/StorageFileTest";
-    private static final String NON_EXISTANT_FILE_NAME = "ThisFileDoesNotExist.txt";
-
     @TempDir
     public static Path testFolder;
+
+    private static final String TEST_DATA_FOLDER = "test/data/StorageFileTest";
+    private static final String NON_EXISTANT_FILE_NAME = "ThisFileDoesNotExist.txt";
 
     @Test
     public void constructor_nullFilePath_exceptionThrown() throws Exception {
@@ -52,20 +51,20 @@ public class StorageFileTest {
 
     @Test
     public void load_validFormat() throws Exception {
-        AddressBook actualAB = getStorage("ValidData.txt").load();
-        AddressBook expectedAB = getTestAddressBook();
+        AddressBook actualAb = getStorage("ValidData.txt").load();
+        AddressBook expectedAb = getTestAddressBook();
 
         // ensure loaded AddressBook is properly constructed with test data
         // TODO: overwrite equals method in AddressBook class and replace with equals method below
-        assertEquals(actualAB.getAllPersons(), expectedAB.getAllPersons());
+        assertEquals(actualAb.getAllPersons(), expectedAb.getAllPersons());
     }
 
     @Test
     public void load_nonExistantFile_returnsEmptyAddressBook() throws Exception {
-        AddressBook actualAB = getStorage(NON_EXISTANT_FILE_NAME).load();
-        AddressBook expectedAB = new AddressBook();
+        AddressBook actualAb = getStorage(NON_EXISTANT_FILE_NAME).load();
+        AddressBook expectedAb = new AddressBook();
 
-        assertEquals(actualAB, expectedAB);
+        assertEquals(actualAb, expectedAb);
 
         // verify that loading does not result in the file being created
         assertFileDoesNotExist(TEST_DATA_FOLDER + "/" + NON_EXISTANT_FILE_NAME);

--- a/test/java/seedu/addressbook/util/TestUtil.java
+++ b/test/java/seedu/addressbook/util/TestUtil.java
@@ -24,6 +24,9 @@ import seedu.addressbook.data.person.Phone;
 import seedu.addressbook.data.person.ReadOnlyPerson;
 import seedu.addressbook.data.person.UniquePersonList.DuplicatePersonException;
 
+/**
+ * Utility methods for testing.
+ */
 public class TestUtil {
     /**
      * Creates an address book containing the given persons.
@@ -104,6 +107,10 @@ public class TestUtil {
         return numberOfElementsSeen;
     }
 
+    /**
+     * Generates an instance of a {@code Person} from valid test data.
+     * @return an instance of a {@code Person}.
+     */
     public static Person generateTestPerson() {
         try {
             return new Person(new Name(Name.EXAMPLE), new Phone(Phone.EXAMPLE, false),

--- a/test/java/seedu/addressbook/util/TypicalPersons.java
+++ b/test/java/seedu/addressbook/util/TypicalPersons.java
@@ -16,7 +16,10 @@ import seedu.addressbook.data.tag.Tag;
  */
 public class TypicalPersons {
 
-    public Person amy, bill, candy, dan;
+    private Person amy;
+    private Person bill;
+    private Person candy;
+    private Person dan;
 
     public TypicalPersons() {
         try {
@@ -34,6 +37,10 @@ public class TypicalPersons {
         }
     }
 
+    /**
+     * Inserts predefined {@code Person} objects into a given instance of {@code AddressBook}
+     * @param ab AddressBook in which {@code Person} objects will be added.
+     */
     private void loadAddressBookWithSampleData(AddressBook ab) {
         try {
             for (Person p : this.getTypicalPersons()) {
@@ -54,4 +61,19 @@ public class TypicalPersons {
         return ab;
     }
 
+    public Person getAmy() {
+        return amy;
+    }
+
+    public Person getBill() {
+        return bill;
+    }
+
+    public Person getCandy() {
+        return candy;
+    }
+
+    public Person getDan() {
+        return dan;
+    }
 }


### PR DESCRIPTION
Upgrade checkstyle version and checkstyle rules to match that of later
AddressBooks for consistency.

Add checkstyle checks into the buildfile to ensure that future commits
will remain compliant to checkstyle rules.

Fix checkstyle violations as the AddressBooks are meant to be models for
students to learn from.

Modify checkstyle rules to allow JUnit4 annotations until the migration
to JUnit5.